### PR TITLE
fix: deconvolute - no location

### DIFF
--- a/lollipop/cli/deconvolute.py
+++ b/lollipop/cli/deconvolute.py
@@ -553,11 +553,14 @@ def deconvolute(
         logger.ERROR("The number of cores must be at least 1.")
         sys.exit(1)
     # check if there are more cores than locations
-    if n_cores > len(locations_list):
-        logger.warning("The number of cores is greater than the number of locations.")
-        # adjust the number of cores to the number of locations
-        n_cores = len(loc)
-        logger.warning(f"The number of cores has been adjusted to {n_cores}.")
+    if locations_list is not None:
+        if n_cores > len(locations_list):
+            logger.warning(
+                "The number of cores is greater than the number of locations."
+            )
+            # adjust the number of cores to the number of locations
+            n_cores = len(loc)
+            logger.warning(f"The number of cores has been adjusted to {n_cores}.")
 
     # inform on the mode of computation
     print("Available cores (parrallelized by locations): ", n_cores)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -93,3 +93,30 @@ def test_workflow_one_loc_one_core():
             "preprint/data/tallymut_line_full.tsv.zst",
         ]
     )
+
+
+def test_workflow_no_loc():
+    """
+    Tests workflow with no location
+    given.
+    """
+    # data: its handled with LFS
+
+    # dummy run
+    subprocess.check_call(["lollipop", "--version"])
+
+    # do fast test from preprint
+    subprocess.check_call(
+        [
+            "lollipop",
+            "deconvolute",
+            "--n-cores=1",
+            "--output=test_results_oneloc.csv",
+            "--out-json=test_results_oneloc.json",
+            "--variants-config=config_preprint.yaml",
+            "--variants-dates=tests/test_var_dates.yaml",  # only the last month
+            "--deconv-config=presets/deconv_linear.yaml",
+            "--seed=42",
+            "preprint/data/tallymut_line_full.tsv.zst",
+        ]
+    )


### PR DESCRIPTION
This PR addresses: `lollipop deconvolute` not being executable when run without a location argument. 
