### PR TITLE
dev: adding pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.2  # You can update this to the latest stable version
+    rev: 23.3.0  # Aligning with the version specified in pyproject.toml
     hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2  # You can update this to the latest stable version
+    hooks:
+      - id: black
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -471,6 +471,15 @@ poetry-dynamic-versioning
 poetry install --extras "cli"
 ```
 
+For development install all with:
+
+```sh
+poetry install --with dev --extras "cli"
+poetry run pre-commit install
+```
+
+This will ensure you have all tools needed for development, including the pre-commit hook for automatic code formatting with black.
+
 ## Upcoming features
 
 - [ ] Support VCFs and coverage TSV as alternative to basecount TSV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ deconvolute = "lollipop.deconvolute:deconvolute"
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"
 pytest = "^6.2.1"
+pre-commit = "^3.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]


### PR DESCRIPTION
This PR adds `black` as a precommit hook.

This makes developing on lollipop much more convenient as one locally checks the format of the files on each commit. 

Format issues according to black become obvious on the local machine instead of in the CI on github. 

